### PR TITLE
修复1.20.1 Sodium面部渲染与自动眨眼问题

### DIFF
--- a/common/src/main/java/com/github/squi2rel/mcft/AutoBlink.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/AutoBlink.java
@@ -20,12 +20,12 @@ public class AutoBlink {
     private static long lastUpdateTime = System.currentTimeMillis();
 
     public static void update() {
-        if (!config.autoBlink || config.autoSwitchBlink && OSC.lastReceived != lastUpdateTime && System.currentTimeMillis() - OSC.lastReceived < 3000) {
+        long currentTime = System.currentTimeMillis();
+        if (!config.autoBlink || config.autoSwitchBlink && currentTime - OSC.lastOscReceived < 3000) {
             enabled = false;
             return;
         }
         enabled = true;
-        long currentTime = System.currentTimeMillis();
         float delta = currentTime - lastUpdateTime;
         lastUpdateTime = currentTime;
         last += delta;
@@ -50,6 +50,5 @@ public class AutoBlink {
             }
         }
         model.eyeL.percent = model.eyeR.percent = eyeOpenness * config.blinkMaxY;
-        OSC.lastReceived = lastUpdateTime;
     }
 }

--- a/common/src/main/java/com/github/squi2rel/mcft/Config.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/Config.java
@@ -4,6 +4,8 @@ public class Config {
     public int httpPort = 8999;
     public int oscReceivePort = 9000;
     public int oscSendPort = 9001;
+    public String oscBindHost = "127.0.0.1";
+    public String oscTargetHost = "127.0.0.1";
 
     public FTModel model = new FTModel();
     public float eyeXMul = 0.5f, eyeYMul = 0.3f;

--- a/common/src/main/java/com/github/squi2rel/mcft/MCFT.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/MCFT.java
@@ -4,7 +4,6 @@ import com.github.squi2rel.mcft.network.ConfigPayload;
 import com.github.squi2rel.mcft.network.TrackingParamsPayload;
 import com.github.squi2rel.mcft.network.TrackingUpdatePayload;
 import com.google.gson.Gson;
-import net.minecraft.client.resource.language.I18n;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +30,7 @@ public class MCFT {
 
         ServerPacketHandler.registerC2S(TrackingParamsPayload.class, TrackingParamsPayload.ID, TrackingParamsPayload.CODEC, (payload, p) -> {
             FTModel old = models.get(p.getUuid());
-            if (old == null) LOGGER.info(I18n.translate("mcft.logging.playerconnected", Objects.requireNonNull(p.getDisplayName()).getString()));
+            if (old == null) LOGGER.info("Player {} is using MCFT", Objects.requireNonNull(p.getDisplayName()).getString());
             FTModel model = new FTModel(payload.eyeR(), payload.eyeL(), payload.mouth(), payload.flat());
             model.validate(true);
             if (old != null) model.enabled = old.enabled;
@@ -49,7 +48,7 @@ public class MCFT {
             model.validate(false);
             if (!model.enabled) {
                 model.enabled = true;
-                LOGGER.info(I18n.translate("mcft.logging.oscreceived", Objects.requireNonNull(p.getDisplayName()).getString()));
+                LOGGER.info("Player {} has OSC connected", Objects.requireNonNull(p.getDisplayName()).getString());
                 TrackingParamsPayload packet = new TrackingParamsPayload(p.getUuid(), model.eyeR, model.eyeL, model.mouth, model.isFlat);
                 for (ServerPlayerEntity player : Objects.requireNonNull(p.getServer()).getPlayerManager().getPlayerList()) ServerPacketHandler.sendS2C(player, packet);
             }
@@ -58,6 +57,10 @@ public class MCFT {
                     player.getPos().isInRange(p.getPos(), config.syncRadius)
             )) ServerPacketHandler.sendS2C(player, packet);
         });
+
+        ServerPacketHandler.registerS2C(TrackingParamsPayload.class, TrackingParamsPayload.ID, TrackingParamsPayload.CODEC);
+        ServerPacketHandler.registerS2C(TrackingUpdatePayload.class, TrackingUpdatePayload.ID, TrackingUpdatePayload.CODEC);
+        ServerPacketHandler.registerS2C(ConfigPayload.class, ConfigPayload.ID, ConfigPayload.CODEC);
 
         Platform.register();
     }

--- a/common/src/main/java/com/github/squi2rel/mcft/MCFTClient.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/MCFTClient.java
@@ -67,6 +67,7 @@ public class MCFTClient {
     public static void update() {
         if (MC.player == null || MC.world == null) return;
         AutoBlink.update();
+        OSC.applyPendingParameters();
         if (model.active() && System.currentTimeMillis() - lastSync > 1000 / fps) {
             FTClient.writeSync(model);
             lastSync = System.currentTimeMillis();

--- a/common/src/main/java/com/github/squi2rel/mcft/ServerPacketHandler.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/ServerPacketHandler.java
@@ -17,6 +17,11 @@ public class ServerPacketHandler {
     }
 
     @ExpectPlatform
+    public static <P extends CustomPacket<P>> void registerS2C(Class<P> clazz, Identifier id, PacketCodec<PacketByteBuf, P> codec) {
+        throw new AssertionError();
+    }
+
+    @ExpectPlatform
     public static <P extends CustomPacket<P>> void sendS2C(ServerPlayerEntity player, P packet) {
         throw new AssertionError();
     }

--- a/common/src/main/java/com/github/squi2rel/mcft/mixin/MCFTMixinPlugin.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/mixin/MCFTMixinPlugin.java
@@ -1,0 +1,46 @@
+package com.github.squi2rel.mcft.mixin;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MCFTMixinPlugin implements IMixinConfigPlugin {
+    private static final String MODEL_PART_RENDER_MIXIN = "com.github.squi2rel.mcft.mixin.client.ModelPartRenderMixin";
+    private static final String SODIUM_MODEL_PART_MIXIN = "me/jellysquid/mods/sodium/mixin/features/render/entity/ModelPartMixin.class";
+    private boolean sodiumEntityRendererAvailable;
+
+    @Override
+    public void onLoad(String mixinPackage) {
+        sodiumEntityRendererAvailable = MCFTMixinPlugin.class.getClassLoader().getResource(SODIUM_MODEL_PART_MIXIN) != null;
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return !MODEL_PART_RENDER_MIXIN.equals(mixinClassName) || sodiumEntityRendererAvailable;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/common/src/main/java/com/github/squi2rel/mcft/mixin/client/ModelPartAccessor.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/mixin/client/ModelPartAccessor.java
@@ -19,4 +19,10 @@ public interface ModelPartAccessor {
 
     @Accessor("children")
     Map<String, ModelPart> getChildren();
+
+    @Accessor("visible")
+    boolean getVisible();
+
+    @Accessor("hidden")
+    boolean getHidden();
 }

--- a/common/src/main/java/com/github/squi2rel/mcft/mixin/client/ModelPartRenderMixin.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/mixin/client/ModelPartRenderMixin.java
@@ -1,0 +1,83 @@
+package com.github.squi2rel.mcft.mixin.client;
+
+import com.github.squi2rel.mcft.FTCuboid;
+import net.minecraft.client.model.ModelPart;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.util.math.MatrixStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+import java.util.Map;
+
+@Mixin(value = ModelPart.class, priority = 900)
+public class ModelPartRenderMixin {
+    @Unique
+    private static final Class<?> mcft$sodiumModelPartData = mcft$findSodiumModelPartData();
+
+    @Inject(
+            method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumer;IIFFFF)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void mcft$render(
+            MatrixStack matrices, VertexConsumer vertices, int light, int overlay,
+            float red, float green, float blue, float alpha, CallbackInfo ci
+    ) {
+        ModelPart part = (ModelPart) (Object) this;
+        if (mcft$sodiumModelPartData == null || !mcft$sodiumModelPartData.isInstance(part)) return;
+        ModelPartAccessor accessor = (ModelPartAccessor) (Object) part;
+        List<ModelPart.Cuboid> cuboids = accessor.getCuboids();
+        if (!mcft$containsCustomCuboid(cuboids)) return;
+        mcft$renderVanilla(part, accessor, cuboids, matrices, vertices, light, overlay, red, green, blue, alpha);
+        ci.cancel();
+    }
+
+    @Unique
+    private static Class<?> mcft$findSodiumModelPartData() {
+        try {
+            return Class.forName(
+                    "me.jellysquid.mods.sodium.client.render.immediate.model.ModelPartData",
+                    false,
+                    ModelPart.class.getClassLoader()
+            );
+        } catch (ClassNotFoundException | LinkageError ignored) {
+            return null;
+        }
+    }
+
+    @Unique
+    private static boolean mcft$containsCustomCuboid(List<ModelPart.Cuboid> cuboids) {
+        for (ModelPart.Cuboid cuboid : cuboids) {
+            if (cuboid instanceof FTCuboid) return true;
+        }
+        return false;
+    }
+
+    @Unique
+    private static void mcft$renderVanilla(
+            ModelPart part, ModelPartAccessor accessor, List<ModelPart.Cuboid> cuboids,
+            MatrixStack matrices, VertexConsumer vertices, int light, int overlay,
+            float red, float green, float blue, float alpha
+    ) {
+        if (!accessor.getVisible()) return;
+        Map<String, ModelPart> children = accessor.getChildren();
+        if (cuboids.isEmpty() && children.isEmpty()) return;
+
+        matrices.push();
+        part.rotate(matrices);
+        if (!accessor.getHidden()) {
+            MatrixStack.Entry entry = matrices.peek();
+            for (ModelPart.Cuboid cuboid : cuboids) {
+                cuboid.renderCuboid(entry, vertices, light, overlay, red, green, blue, alpha);
+            }
+        }
+        for (ModelPart child : children.values()) {
+            child.render(matrices, vertices, light, overlay, red, green, blue, alpha);
+        }
+        matrices.pop();
+    }
+}

--- a/common/src/main/java/com/github/squi2rel/mcft/services/DNS.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/services/DNS.java
@@ -7,22 +7,65 @@ import java.net.*;
 import java.util.concurrent.TimeUnit;
 
 public class DNS {
+    private static final Object lock = new Object();
+    private static volatile boolean running;
+    private static Thread thread;
     public static final int port = 5353;
     public static void init() {
-        Thread dns = new Thread(() -> {
-            while (true) {
-                try {
-                    TimeUnit.SECONDS.sleep(10);
-                    sendReply();
-                } catch (InterruptedException ignored) {
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+        synchronized (lock) {
+            if (running) return;
+            running = true;
+            Thread candidate = new Thread(DNS::run);
+            candidate.setName("MCFT DNS");
+            candidate.setDaemon(true);
+            thread = candidate;
+            try {
+                candidate.start();
+            } catch (RuntimeException e) {
+                thread = null;
+                running = false;
+                throw e;
             }
-        });
-        dns.setDaemon(true);
-        dns.start();
+        }
         MCFT.LOGGER.info("DNS started on port {}", port);
+    }
+
+    public static void shutdown() {
+        Thread current;
+        synchronized (lock) {
+            running = false;
+            current = thread;
+            thread = null;
+        }
+        if (current != null) current.interrupt();
+    }
+
+    private static void run() {
+        Thread current = Thread.currentThread();
+        boolean failureLogged = false;
+        while (running && thread == current) {
+            try {
+                sendReply();
+                if (failureLogged) MCFT.LOGGER.info("DNS replies resumed");
+                failureLogged = false;
+            } catch (Exception e) {
+                if (!failureLogged) MCFT.LOGGER.error("DNS reply failed", e);
+                failureLogged = true;
+            }
+            if (!running || thread != current) break;
+            try {
+                TimeUnit.SECONDS.sleep(10);
+            } catch (InterruptedException ignored) {
+                current.interrupt();
+                break;
+            }
+        }
+        synchronized (lock) {
+            if (thread == current) {
+                thread = null;
+                running = false;
+            }
+        }
     }
 
     private static void sendReply() throws Exception {

--- a/common/src/main/java/com/github/squi2rel/mcft/services/HTTP.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/services/HTTP.java
@@ -14,8 +14,12 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.Session;
 
 import java.io.*;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
@@ -25,37 +29,168 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 public class HTTP {
+    private static final Object lifecycleLock = new Object();
+    private static final Object lock = new Object();
+    private static final String HTTP_LOOPBACK_HOST = "127.0.0.1";
+    private static final int SOCKET_READ_TIMEOUT = 5000;
+    private static final int MAX_HEADER_BYTES = 16384;
     public static final int port = MCFTClient.config.httpPort;
-    public static void init() throws IOException {
-        createInfo();
-        Thread http = new Thread(() -> {
-            try (ServerSocket serverSocket = new ServerSocket(port)) {
-                OSC.init();
+    private static ServerSocket serverSocket;
+    private static Thread httpThread;
+
+    public static void init() {
+        synchronized (lifecycleLock) {
+            initServices();
+        }
+    }
+
+    private static void initServices() {
+        try {
+            OSC.init();
+        } catch (Exception e) {
+            MCFT.LOGGER.error("OSC start failed", e);
+        }
+        if (MinecraftClient.getInstance().getSession().getUuidOrNull() == null) {
+            MCFT.LOGGER.warn("OSCQuery start skipped without a session UUID");
+            return;
+        }
+        try {
+            createInfo();
+        } catch (Exception e) {
+            MCFT.LOGGER.error("OSC avatar info creation failed", e);
+        }
+        boolean httpStarted = false;
+        try {
+            httpStarted = startServer();
+        } catch (Exception e) {
+            MCFT.LOGGER.error("HTTP start failed", e);
+        }
+        if (httpStarted) {
+            try {
                 DNS.init();
-                MCFT.LOGGER.info("HTTP started on port {}", port);
-                while (true) {
-                    try (Socket s = serverSocket.accept()) {
-                        BufferedReader in = new BufferedReader(new InputStreamReader(s.getInputStream()));
-                        while (true) {
-                            String headerLine = in.readLine();
-                            if (headerLine == null || headerLine.isEmpty()) {
-                                break;
-                            }
-                        }
-                        String response = getString();
-                        OutputStream out = s.getOutputStream();
-                        out.write(response.getBytes(StandardCharsets.UTF_8));
-                        out.flush();
-                    } catch (IOException ignored) {
-                    }
-                }
             } catch (Exception e) {
-                MCFT.LOGGER.error("Service start failed", e);
+                MCFT.LOGGER.error("DNS start failed", e);
             }
-        });
-        http.setName("MCFT Service");
-        http.setDaemon(true);
-        http.start();
+        }
+    }
+
+    public static void shutdown() {
+        synchronized (lifecycleLock) {
+            shutdownServices();
+        }
+    }
+
+    private static void shutdownServices() {
+        ServerSocket current;
+        synchronized (lock) {
+            current = serverSocket;
+            serverSocket = null;
+            httpThread = null;
+        }
+        if (current != null) {
+            try {
+                current.close();
+            } catch (IOException e) {
+                MCFT.LOGGER.error("Failed to close HTTP server", e);
+            }
+        }
+        OSC.shutdown();
+        DNS.shutdown();
+    }
+
+    private static boolean startServer() throws IOException {
+        synchronized (lock) {
+            if (serverSocket != null && !serverSocket.isClosed() && httpThread != null && httpThread.isAlive()) return true;
+            requirePort(port);
+            ServerSocket candidate = new ServerSocket();
+            try {
+                candidate.bind(new InetSocketAddress(InetAddress.getByName(HTTP_LOOPBACK_HOST), port));
+                Thread thread = new Thread(() -> runServer(candidate));
+                thread.setName("MCFT HTTP");
+                thread.setDaemon(true);
+                serverSocket = candidate;
+                httpThread = thread;
+                thread.start();
+                MCFT.LOGGER.info("HTTP started on {}:{}", HTTP_LOOPBACK_HOST, port);
+                return true;
+            } catch (IOException | RuntimeException e) {
+                if (serverSocket == candidate) {
+                    serverSocket = null;
+                    httpThread = null;
+                }
+                try {
+                    candidate.close();
+                } catch (IOException closeException) {
+                    e.addSuppressed(closeException);
+                }
+                throw e;
+            }
+        }
+    }
+
+    private static void runServer(ServerSocket socket) {
+        try {
+            while (!socket.isClosed()) {
+                Socket client;
+                try {
+                    client = socket.accept();
+                } catch (IOException e) {
+                    if (!socket.isClosed()) MCFT.LOGGER.error("HTTP accept failed", e);
+                    break;
+                }
+                try (client) {
+                    handleClient(client);
+                } catch (SocketTimeoutException | SocketException ignored) {
+                } catch (IOException e) {
+                    MCFT.LOGGER.error("HTTP request failed", e);
+                } catch (RuntimeException e) {
+                    MCFT.LOGGER.error("HTTP request failed", e);
+                }
+            }
+        } finally {
+            try {
+                socket.close();
+            } catch (IOException e) {
+                MCFT.LOGGER.error("Failed to close HTTP server", e);
+            }
+            boolean stoppedCurrent = false;
+            synchronized (lock) {
+                if (serverSocket == socket) {
+                    serverSocket = null;
+                    httpThread = null;
+                    stoppedCurrent = true;
+                }
+            }
+            if (stoppedCurrent) DNS.shutdown();
+        }
+    }
+
+    private static void handleClient(Socket client) throws IOException {
+        client.setSoTimeout(SOCKET_READ_TIMEOUT);
+        readHeaders(client.getInputStream());
+        String response = getString();
+        OutputStream out = client.getOutputStream();
+        out.write(response.getBytes(StandardCharsets.UTF_8));
+        out.flush();
+    }
+
+    private static void readHeaders(InputStream input) throws IOException {
+        int third = -1;
+        int second = -1;
+        int previous = -1;
+        for (int count = 0; count < MAX_HEADER_BYTES; count++) {
+            int current = input.read();
+            if (current == -1) return;
+            if (previous == '\n' && current == '\n' || third == '\r' && second == '\n' && previous == '\r' && current == '\n') return;
+            third = second;
+            second = previous;
+            previous = current;
+        }
+        throw new IOException("HTTP request headers exceed " + MAX_HEADER_BYTES + " bytes");
+    }
+
+    private static void requirePort(int value) {
+        if (value < 1 || value > 65535) throw new IllegalArgumentException("httpPort must be between 1 and 65535");
     }
 
     private static String getString() throws IOException {

--- a/common/src/main/java/com/github/squi2rel/mcft/services/OSC.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/services/OSC.java
@@ -9,54 +9,163 @@ import com.illposed.osc.transport.OSCPortIn;
 import com.illposed.osc.transport.OSCPortOut;
 import net.minecraft.client.MinecraftClient;
 
+import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 import static com.github.squi2rel.mcft.FTModel.model;
 import static com.github.squi2rel.mcft.MCFTClient.config;
 
 public class OSC {
-    public static long lastReceived = 0;
-    public static Map<String, Consumer<List<Object>>> allParameters = Map.ofEntries(
-            Map.entry("EyeLeftX", f -> model.eyeL.rawPos.x = config.eyeOffsetXL + (float) f.get(0) * -config.eyeXMul),
-            Map.entry("EyeLeftY", f -> model.eyeL.rawPos.y = config.eyeOffsetYL + (float) f.get(0) * -config.eyeYMul),
+    private static final Object lock = new Object();
+    private static final Map<String, Float> pendingParameters = new ConcurrentHashMap<>();
+    private static OSCPortIn receiver;
+    public static volatile long lastOscReceived = 0;
+    public static volatile long lastReceived = 0;
+    public static final Map<String, Consumer<Float>> allParameters = Map.ofEntries(
+            Map.entry("EyeLeftX", f -> model.eyeL.rawPos.x = config.eyeOffsetXL + f * -config.eyeXMul),
+            Map.entry("EyeLeftY", f -> model.eyeL.rawPos.y = config.eyeOffsetYL + f * -config.eyeYMul),
             Map.entry("EyeLidLeft", f -> {
-                if (!AutoBlink.enabled) model.eyeL.percent = (float) f.get(0);
+                if (!config.autoBlink || config.autoSwitchBlink) model.eyeL.percent = f;
             }),
-            Map.entry("EyeRightX", f -> model.eyeR.rawPos.x = config.eyeOffsetXR + (float) f.get(0) * -config.eyeXMul),
-            Map.entry("EyeRightY", f -> model.eyeR.rawPos.y = config.eyeOffsetYR + (float) f.get(0) * -config.eyeYMul),
+            Map.entry("EyeRightX", f -> model.eyeR.rawPos.x = config.eyeOffsetXR + f * -config.eyeXMul),
+            Map.entry("EyeRightY", f -> model.eyeR.rawPos.y = config.eyeOffsetYR + f * -config.eyeYMul),
             Map.entry("EyeLidRight", f -> {
-                if (!AutoBlink.enabled) model.eyeR.percent = (float) f.get(0);
+                if (!config.autoBlink || config.autoSwitchBlink) model.eyeR.percent = f;
             }),
-            Map.entry("JawOpen", f -> model.mouth.percent = (float) f.get(0))
+            Map.entry("JawOpen", f -> model.mouth.percent = f)
     );
 
     public static void init() throws Exception {
-        OSCPortIn receiver = new OSCPortIn(new InetSocketAddress("localhost", config.oscReceivePort));
-        OSCPortOut sender = new OSCPortOut(new InetSocketAddress("localhost", config.oscSendPort));
-        receiver.getDispatcher().addListener(new MessageSelector() {
-            @Override
-            public boolean isInfoRequired() {
-                return false;
-            }
+        InetAddress bindAddress = resolveLoopback(config.oscBindHost, "oscBindHost");
+        int receivePort = requirePort(config.oscReceivePort, "oscReceivePort");
+        synchronized (lock) {
+            if (receiver != null && receiver.isListening()) return;
+            closeReceiver();
+            OSCPortIn candidate = null;
+            try {
+                candidate = new OSCPortIn(new InetSocketAddress(bindAddress, receivePort));
+                candidate.getDispatcher().addListener(new MessageSelector() {
+                    @Override
+                    public boolean isInfoRequired() {
+                        return false;
+                    }
 
-            @Override
-            public boolean matches(OSCMessageEvent oscMessageEvent) {
-                return true;
+                    @Override
+                    public boolean matches(OSCMessageEvent oscMessageEvent) {
+                        return true;
+                    }
+                }, OSC::handleMessage);
+                candidate.startListening();
+                receiver = candidate;
+                candidate = null;
+            } finally {
+                if (candidate != null) candidate.close();
             }
-        }, e -> {
-            OSCMessage msg = e.getMessage();
-            Consumer<List<Object>> c = allParameters.get(msg.getAddress().replace("/v2/", ""));
-            if (c != null) {
-                lastReceived = System.currentTimeMillis();
-                c.accept(msg.getArguments());
+        }
+        MCFT.LOGGER.info("OSC started on {}:{}", bindAddress.getHostAddress(), receivePort);
+        try {
+            InetAddress targetAddress = resolveLoopback(config.oscTargetHost, "oscTargetHost");
+            int sendPort = requirePort(config.oscSendPort, "oscSendPort");
+            sendAvatarChange(targetAddress, sendPort);
+        } catch (Exception e) {
+            MCFT.LOGGER.error("OSC avatar change target is invalid", e);
+        }
+    }
+
+    public static void applyPendingParameters() {
+        lastReceived = AutoBlink.enabled ? System.currentTimeMillis() : lastOscReceived;
+        pendingParameters.forEach((name, value) -> {
+            if (pendingParameters.remove(name, value)) {
+                try {
+                    allParameters.get(name).accept(value);
+                } catch (RuntimeException e) {
+                    MCFT.LOGGER.error("Failed to apply OSC parameter {}", name, e);
+                }
             }
         });
-        receiver.startListening();
-        MCFT.LOGGER.info("OSC started on port {}", 9000);
-        sender.send(new OSCMessage("/avatar/change", List.of(Objects.requireNonNull(MinecraftClient.getInstance().getSession().getUuidOrNull()).toString())));
+    }
+
+    public static void shutdown() {
+        synchronized (lock) {
+            try {
+                closeReceiver();
+            } catch (IOException e) {
+                MCFT.LOGGER.error("Failed to close OSC receiver", e);
+            }
+            pendingParameters.clear();
+        }
+    }
+
+    private static void handleMessage(OSCMessageEvent event) {
+        String address = "unknown";
+        try {
+            OSCMessage message = event.getMessage();
+            address = message.getAddress();
+            if (!address.startsWith("/v2/")) return;
+            String parameter = address.substring(4);
+            if (!allParameters.containsKey(parameter)) return;
+            List<Object> arguments = message.getArguments();
+            if (arguments.size() != 1 || !(arguments.get(0) instanceof Number value)) {
+                MCFT.LOGGER.warn("Ignored invalid OSC arguments for {}", address);
+                return;
+            }
+            float argument = value.floatValue();
+            if (!Float.isFinite(argument)) {
+                MCFT.LOGGER.warn("Ignored non-finite OSC argument for {}", address);
+                return;
+            }
+            lastOscReceived = System.currentTimeMillis();
+            pendingParameters.put(parameter, argument);
+        } catch (RuntimeException e) {
+            MCFT.LOGGER.error("Failed to handle OSC message {}", address, e);
+        }
+    }
+
+    private static void sendAvatarChange(InetAddress targetAddress, int sendPort) {
+        UUID uuid = MinecraftClient.getInstance().getSession().getUuidOrNull();
+        if (uuid == null) {
+            MCFT.LOGGER.warn("Skipped OSC avatar change without a session UUID");
+            return;
+        }
+        OSCPortOut sender = null;
+        try {
+            sender = new OSCPortOut(new InetSocketAddress(targetAddress, sendPort));
+            sender.send(new OSCMessage("/avatar/change", List.of(uuid.toString())));
+        } catch (Exception e) {
+            MCFT.LOGGER.error("Failed to send OSC avatar change to {}:{}", targetAddress.getHostAddress(), sendPort, e);
+        } finally {
+            if (sender != null) {
+                try {
+                    sender.close();
+                } catch (IOException e) {
+                    MCFT.LOGGER.error("Failed to close OSC sender", e);
+                }
+            }
+        }
+    }
+
+    private static InetAddress resolveLoopback(String host, String setting) throws IOException {
+        if (host == null || host.isBlank()) throw new IllegalArgumentException(setting + " must not be blank");
+        InetAddress address = InetAddress.getByName(host);
+        if (!address.isLoopbackAddress()) throw new IllegalArgumentException(setting + " must resolve to a loopback address");
+        return address;
+    }
+
+    private static int requirePort(int port, String setting) {
+        if (port < 1 || port > 65535) throw new IllegalArgumentException(setting + " must be between 1 and 65535");
+        return port;
+    }
+
+    private static void closeReceiver() throws IOException {
+        if (receiver == null) return;
+        OSCPortIn current = receiver;
+        receiver = null;
+        current.close();
     }
 }

--- a/common/src/main/resources/mcft.mixins.json
+++ b/common/src/main/resources/mcft.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "com.github.squi2rel.mcft.mixin",
+  "plugin": "com.github.squi2rel.mcft.mixin.MCFTMixinPlugin",
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "client": [
@@ -10,6 +11,7 @@
     "client.GameRendererMixin",
     "client.ModelPartAccessor",
     "client.ModelPartDataMixin",
+    "client.ModelPartRenderMixin",
     "client.PlayerEntityModelMixin",
     "client.PlayerEntityRendererMixin",
     "client.VertexAccessor"

--- a/fabric/src/main/java/com/github/squi2rel/mcft/fabric/ServerPacketHandlerImpl.java
+++ b/fabric/src/main/java/com/github/squi2rel/mcft/fabric/ServerPacketHandlerImpl.java
@@ -19,6 +19,9 @@ public class ServerPacketHandlerImpl {
         });
     }
 
+    public static <P extends CustomPacket<P>> void registerS2C(Class<P> clazz, Identifier id, PacketCodec<PacketByteBuf, P> codec) {
+    }
+
     public static <P extends CustomPacket<P>> void sendS2C(ServerPlayerEntity player, P packet) {
         PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
         packet.getCodec().writer().accept(packet, buf);

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
   "accessWidener": "mcft.accesswidener",
   "depends": {
     "fabricloader": ">=0.17.2",
-    "minecraft": "~1.20.1",
+    "minecraft": "1.20.1",
     "java": ">=17",
     "fabric-api": "*"
   },

--- a/forge/src/main/java/com/github/squi2rel/mcft/forge/ClientPlatformEvents.java
+++ b/forge/src/main/java/com/github/squi2rel/mcft/forge/ClientPlatformEvents.java
@@ -1,0 +1,17 @@
+package com.github.squi2rel.mcft.forge;
+
+import com.github.squi2rel.mcft.MCFTClient;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraftforge.client.event.RegisterClientCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+public class ClientPlatformEvents {
+    @SubscribeEvent
+    public static void onCommandRegister(RegisterClientCommandsEvent event) {
+        event.getDispatcher().register(LiteralArgumentBuilder.<ServerCommandSource>literal("mcft").executes(s -> {
+            MCFTClient.configScreen = true;
+            return 1;
+        }));
+    }
+}

--- a/forge/src/main/java/com/github/squi2rel/mcft/forge/PacketHandlers.java
+++ b/forge/src/main/java/com/github/squi2rel/mcft/forge/PacketHandlers.java
@@ -36,13 +36,19 @@ public class PacketHandlers {
         channels.computeIfAbsent(clazz, k -> register(clazz, id, codec)).serverHandler = (p, s) -> receiver.accept((P) p, s);
     }
 
+    public static <P extends CustomPacket<P>> void registerS2C(Class<P> clazz, Identifier id, PacketCodec<PacketByteBuf, P> codec) {
+        channels.computeIfAbsent(clazz, k -> register(clazz, id, codec));
+    }
+
     public static <P extends CustomPacket<P>> void sendS2C(ServerPlayerEntity player, P packet) {
         channels.get(packet.getClass()).channel.send(PacketDistributor.PLAYER.with(() -> player), packet);
     }
 
     @SuppressWarnings("unchecked")
     public static <P extends CustomPacket<P>> void registerS2C(Class<P> clazz, Identifier id, PacketCodec<PacketByteBuf, P> codec, Consumer<P> receiver) {
-        channels.computeIfAbsent(clazz, k -> register(clazz, id, codec)).clientHandler = p -> receiver.accept((P) p);
+        Handler<P> handler = (Handler<P>) channels.get(clazz);
+        if (handler == null) throw new IllegalStateException("Unregistered clientbound payload " + id);
+        handler.clientHandler = receiver;
     }
 
     public static <P extends CustomPacket<P>> void sendC2S(P packet) {

--- a/forge/src/main/java/com/github/squi2rel/mcft/forge/PlatformImpl.java
+++ b/forge/src/main/java/com/github/squi2rel/mcft/forge/PlatformImpl.java
@@ -1,18 +1,11 @@
 package com.github.squi2rel.mcft.forge;
 
 import com.github.squi2rel.mcft.MCFT;
-import com.github.squi2rel.mcft.MCFTClient;
-import com.mojang.brigadier.CommandDispatcher;
-import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraftforge.client.ClientCommandHandler;
-import net.minecraftforge.client.event.RegisterClientCommandsEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.ModList;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.loading.FMLPaths;
 
 import java.nio.file.Path;
@@ -35,14 +28,7 @@ public class PlatformImpl {
     }
 
     public static void registerCommand() {
-    }
-
-    @SubscribeEvent
-    public static void onCommandRegister(RegisterClientCommandsEvent event) {
-        event.getDispatcher().register(LiteralArgumentBuilder.<ServerCommandSource>literal("mcft").executes(s -> {
-            MCFTClient.configScreen = true;
-            return 1;
-        }));
+        MinecraftForge.EVENT_BUS.register(ClientPlatformEvents.class);
     }
 
     @SubscribeEvent

--- a/forge/src/main/java/com/github/squi2rel/mcft/forge/ServerPacketHandlerImpl.java
+++ b/forge/src/main/java/com/github/squi2rel/mcft/forge/ServerPacketHandlerImpl.java
@@ -14,6 +14,10 @@ public class ServerPacketHandlerImpl {
         PacketHandlers.registerC2S(clazz, id, codec, receiver);
     }
 
+    public static <P extends CustomPacket<P>> void registerS2C(Class<P> clazz, Identifier id, PacketCodec<PacketByteBuf, P> codec) {
+        PacketHandlers.registerS2C(clazz, id, codec);
+    }
+
     public static <P extends CustomPacket<P>> void sendS2C(ServerPlayerEntity player, P packet) {
         PacketHandlers.sendS2C(player, packet);
     }

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[47,)"
+loaderVersion = "[47,48)"
 #issueTrackerURL = ""
 license = "MIT"
 
@@ -16,13 +16,13 @@ Face Tracking for Minecraft
 [[dependencies.mcft]]
 modId = "forge"
 mandatory = true
-versionRange = "[47,)"
+versionRange = "[47,48)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.mcft]]
 modId = "minecraft"
 mandatory = true
-versionRange = "[1.20.1,)"
+versionRange = "[1.20.1,1.20.2)"
 ordering = "NONE"
 side = "BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 1.0.4.6
+mod_version = 1.0.4.7
 maven_group = com.github.squi2rel.mcft
 archives_name = mcft
 enabled_platforms = fabric,forge,quilt

--- a/quilt/src/main/java/com/github/squi2rel/mcft/quilt/ServerPacketHandlerImpl.java
+++ b/quilt/src/main/java/com/github/squi2rel/mcft/quilt/ServerPacketHandlerImpl.java
@@ -19,6 +19,9 @@ public class ServerPacketHandlerImpl {
         });
     }
 
+    public static <P extends CustomPacket<P>> void registerS2C(Class<P> clazz, Identifier id, PacketCodec<PacketByteBuf, P> codec) {
+    }
+
     public static <P extends CustomPacket<P>> void sendS2C(ServerPlayerEntity player, P packet) {
         PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
         packet.getCodec().writer().accept(packet, buf);

--- a/quilt/src/main/resources/quilt.mod.json
+++ b/quilt/src/main/resources/quilt.mod.json
@@ -21,7 +21,7 @@
     "depends": [
       {
         "id": "quilt_loader",
-        "version": "*"
+        "version": ">=0.29.1"
       },
       {
         "id": "quilt_base",
@@ -29,7 +29,7 @@
       },
       {
         "id": "minecraft",
-        "version": ">=1.20.1"
+        "version": "1.20.1"
       }
     ]
   },


### PR DESCRIPTION
Fixes #9 中Minecraft 1.20.1安装 sodium 后自动眨眼和面部动画无法正常生效的问题
Fixes #8 所述 OSC IPv4 地址问题的 1.20.1 版本修复，包括使用 127.0.0.1 作为默认回环地址、OSC 参数校验、客户端线程参数应用以及网络服务生命周期处理
未进行测试