### PR TITLE
Port Sodium rendering fix to multiplatform-1.21.4

### DIFF
--- a/common/src/main/java/com/github/squi2rel/mcft/mixin/MCFTMixinPlugin.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/mixin/MCFTMixinPlugin.java
@@ -1,0 +1,55 @@
+package com.github.squi2rel.mcft.mixin;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MCFTMixinPlugin implements IMixinConfigPlugin {
+    private static final String MODEL_PART_RENDER_MIXIN = "com.github.squi2rel.mcft.mixin.client.ModelPartRenderMixin";
+    private static final String[] SODIUM_MODEL_PART_MIXINS = {
+            "net/caffeinemc/mods/sodium/mixin/features/render/entity/ModelPartMixin.class",
+            "me/jellysquid/mods/sodium/mixin/features/render/entity/ModelPartMixin.class"
+    };
+    private boolean sodiumEntityRendererAvailable;
+
+    @Override
+    public void onLoad(String mixinPackage) {
+        ClassLoader loader = MCFTMixinPlugin.class.getClassLoader();
+        for (String resource : SODIUM_MODEL_PART_MIXINS) {
+            if (loader.getResource(resource) != null) {
+                sodiumEntityRendererAvailable = true;
+                break;
+            }
+        }
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return !MODEL_PART_RENDER_MIXIN.equals(mixinClassName) || sodiumEntityRendererAvailable;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/common/src/main/java/com/github/squi2rel/mcft/mixin/client/ModelPartAccessor.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/mixin/client/ModelPartAccessor.java
@@ -19,4 +19,10 @@ public interface ModelPartAccessor {
 
     @Accessor("children")
     Map<String, ModelPart> getChildren();
+
+    @Accessor("visible")
+    boolean getVisible();
+
+    @Accessor("hidden")
+    boolean getHidden();
 }

--- a/common/src/main/java/com/github/squi2rel/mcft/mixin/client/ModelPartRenderMixin.java
+++ b/common/src/main/java/com/github/squi2rel/mcft/mixin/client/ModelPartRenderMixin.java
@@ -1,0 +1,82 @@
+package com.github.squi2rel.mcft.mixin.client;
+
+import com.github.squi2rel.mcft.FTCuboid;
+import net.minecraft.client.model.ModelPart;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.util.math.MatrixStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+import java.util.Map;
+
+@Mixin(value = ModelPart.class, priority = 900)
+public class ModelPartRenderMixin {
+    @Unique
+    private static final Class<?> mcft$sodiumModelPartData = mcft$findSodiumModelPartData();
+
+    @Inject(
+            method = "render(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumer;III)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void mcft$render(
+            MatrixStack matrices, VertexConsumer vertices, int light, int overlay, int color, CallbackInfo ci
+    ) {
+        ModelPart part = (ModelPart) (Object) this;
+        if (mcft$sodiumModelPartData == null || !mcft$sodiumModelPartData.isInstance(part)) return;
+        ModelPartAccessor accessor = (ModelPartAccessor) (Object) part;
+        List<ModelPart.Cuboid> cuboids = accessor.getCuboids();
+        if (!mcft$containsCustomCuboid(cuboids)) return;
+        mcft$renderVanilla(part, accessor, cuboids, matrices, vertices, light, overlay, color);
+        ci.cancel();
+    }
+
+    @Unique
+    private static Class<?> mcft$findSodiumModelPartData() {
+        for (String name : new String[]{
+                "net.caffeinemc.mods.sodium.client.render.immediate.model.ModelPartData",
+                "me.jellysquid.mods.sodium.client.render.immediate.model.ModelPartData"
+        }) {
+            try {
+                return Class.forName(name, false, ModelPart.class.getClassLoader());
+            } catch (ClassNotFoundException | LinkageError ignored) {
+            }
+        }
+        return null;
+    }
+
+    @Unique
+    private static boolean mcft$containsCustomCuboid(List<ModelPart.Cuboid> cuboids) {
+        for (ModelPart.Cuboid cuboid : cuboids) {
+            if (cuboid instanceof FTCuboid) return true;
+        }
+        return false;
+    }
+
+    @Unique
+    private static void mcft$renderVanilla(
+            ModelPart part, ModelPartAccessor accessor, List<ModelPart.Cuboid> cuboids,
+            MatrixStack matrices, VertexConsumer vertices, int light, int overlay, int color
+    ) {
+        if (!accessor.getVisible()) return;
+        Map<String, ModelPart> children = accessor.getChildren();
+        if (cuboids.isEmpty() && children.isEmpty()) return;
+
+        matrices.push();
+        part.rotate(matrices);
+        if (!accessor.getHidden()) {
+            MatrixStack.Entry entry = matrices.peek();
+            for (ModelPart.Cuboid cuboid : cuboids) {
+                cuboid.renderCuboid(entry, vertices, light, overlay, color);
+            }
+        }
+        for (ModelPart child : children.values()) {
+            child.render(matrices, vertices, light, overlay, color);
+        }
+        matrices.pop();
+    }
+}

--- a/common/src/main/resources/mcft.mixins.json
+++ b/common/src/main/resources/mcft.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "com.github.squi2rel.mcft.mixin",
+  "plugin": "com.github.squi2rel.mcft.mixin.MCFTMixinPlugin",
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "client": [
@@ -9,6 +10,7 @@
     "client.GameRendererMixin",
     "client.ModelPartAccessor",
     "client.ModelPartDataMixin",
+    "client.ModelPartRenderMixin",
     "client.PlayerEntityModelMixin",
     "client.PlayerEntityRendererMixin",
     "client.VertexAccessor"


### PR DESCRIPTION
## 背景

#9 反馈"所有配置成功后自动眨眼无法生效",根因是 Sodium 的实体渲染优化绕过了原版 `Cuboid#renderCuboid` 调用,导致 `FTCuboid` 的动态面部绘制(包括自动眨眼)完全不执行。#10 已在 `multiplatform-1.20.1` 分支加入 Sodium 兼容层,但 #11 移植到本分支时只包含了 OSC 修复,缺少 Sodium 渲染部分。本 PR 补齐这部分,使两个分支的修复保持一致。

## 改动

- 新增 `MCFTMixinPlugin`:仅当 classpath 上存在 Sodium 实体渲染 mixin 时才启用兼容 mixin;同时检测 Sodium 0.5(`me.jellysquid`)与 0.6(`net.caffeinemc`)两代包名。
- 新增 `ModelPartRenderMixin`(priority 900):在 `ModelPart#render` HEAD 注入,先于 Sodium 的可取消回调执行;当部件包含 `FTCuboid` 时按原版逻辑渲染(走到 `FTCuboid#renderCuboid`)并取消,其余部件不受影响、照常使用 Sodium 优化路径。已适配 1.21.4 的 `render(...III)V` 签名(int 颜色)。
- `ModelPartAccessor` 增加 `visible`/`hidden` 访问器(与 1.20.1 分支版本一致)。
- `mcft.mixins.json` 注册插件与新 mixin。

## 说明

Sodium 0.6.x(1.21.4 对应版本)当前的拦截点在 `Cube#compile` 基类方法内(cancellable `@Inject`),`FTCuboid` 重写了该方法会天然绕过拦截,因此在现有版本组合下该兼容层保持惰性(运行时探测不到 0.5 风格的 `ModelPartData` 类时不介入渲染)。此移植主要作为与 1.20.1 分支一致的防护层,防止 ModelPart 级接管式渲染路径(如 Sodium 0.5 风格)在 1.21.4 生态中出现时再次破坏面部渲染。

Refs #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
